### PR TITLE
Add space-before-function-paren rule

### DIFF
--- a/react-library/.eslintrc
+++ b/react-library/.eslintrc
@@ -14,6 +14,11 @@
       "exports": "always-multiline",
       "functions": "ignore"
     }],
+    "space-before-function-paren": ["error", {
+      "anonymous": "never",
+      "named": "never",
+      "asyncArrow": "always"
+    }],
     "jsx-quotes": [
       "error",
       "prefer-double"

--- a/react-spa/.eslintrc
+++ b/react-spa/.eslintrc
@@ -14,6 +14,11 @@
       "exports": "always-multiline",
       "functions": "ignore"
     }],
+    "space-before-function-paren": ["error", {
+      "anonymous": "never",
+      "named": "never",
+      "asyncArrow": "always"
+    }],
     "jsx-quotes": [
       "error",
       "prefer-double"


### PR DESCRIPTION
```json
"space-before-function-paren": ["error", {
  "anonymous": "never",
  "named": "never",
  "asyncArrow": "always"
}],
```

Respectivos exemplos:

`anonymous`:
```js
const fn = function() {
}
```

`named`:
```js
function fn() {
}
```

`asyncArrow`:
```js
const fn = () => {}
```

em classes:
```js
class Apple extends Fruit {
  static get taste() {
  }

  getTaste = () => {
  }

  isBad() {
  }
}
```